### PR TITLE
feat: salary mode toggle + destination rename

### DIFF
--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -47,4 +47,5 @@ Read `references/project-conventions.md` before writing any code.
 ## Rules
 - Never refactor code outside the scope of the issue
 - Keep changes minimal — solve the issue, nothing more
-- write good  unit tests following the Arrange-Act-Assert pattern. Never test underlying libraries unless we have reason to believe they may be faulty. We only test the unit in question, not the systems or libraries the unit relies upon. writing pure functions leveraging DI often avoids lengthy mocking. 
+- Write good unit tests following the Arrange-Act-Assert pattern. Never test underlying libraries unless we have reason to believe they may be faulty. We only test the unit in question, not the systems or libraries the unit relies upon. Writing pure functions leveraging DI often avoids lengthy mocking.
+- **UI work**: never hand-roll interactive elements. Use existing shadcn components from `src/components/ui/`, install missing ones via `npx shadcn@latest add`, and use the Context7 MCP tool to look up current library docs before implementing.

--- a/.claude/skills/developer/references/project-conventions.md
+++ b/.claude/skills/developer/references/project-conventions.md
@@ -6,6 +6,33 @@
 - **UI** uses shadcn/ui + Tailwind; follow patterns in `src/components/calculator/`
 - Read `CLAUDE.md` for full architecture overview
 
+## UI Components
+
+**Never hand-roll interactive UI elements.** Before writing any component:
+
+1. Check `src/components/ui/` for an existing shadcn component that fits.
+2. If nothing fits, install one: `npx shadcn@latest add <component>`
+3. If you have access to the **Context7 MCP tool**, use it to look up current docs for shadcn/ui, Next.js, or any other library in use before implementing — don't rely on memory.
+
+Custom-built toggles, selects, modals, or form controls are not acceptable when a shadcn primitive exists or can be installed.
+
+## E2E Tests
+
+Write Playwright e2e tests in `tests/e2e/` for any UI behaviour you implement. Run them headless — never write ad-hoc scripts to /tmp.
+
+```bash
+npm run test:e2e   # runs headless against port 3938 (playwright starts its own server)
+```
+
+**Important:** The playwright config starts its own dev server on port **3938** — do not change this to 3000 or any other port that conflicts with the developer's running server.
+
+**Composing Radix primitives:** Do not use `asChild` to merge a `TooltipTrigger` onto another Radix primitive (e.g. `TabsTrigger`). It breaks click handling. Wrap the inner primitive in a plain `<span>` instead:
+```tsx
+<TooltipTrigger asChild>
+  <span><TabsTrigger value="x">Label</TabsTrigger></span>
+</TooltipTrigger>
+```
+
 ## Testing
 ```bash
 npm run test:run       # unit tests (Vitest)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   reporter: 'html',
 
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3938',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -25,8 +25,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: 'npm run dev -- --port 3938',
+    url: process.env.BASE_URL ?? 'http://localhost:3938',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },

--- a/src/app/(dashboard)/help/page.tsx
+++ b/src/app/(dashboard)/help/page.tsx
@@ -52,7 +52,7 @@ export default async function HelpPage() {
               <li>Fill in any required inputs (e.g., filing status, region)</li>
               <li>Optionally select a tax variant (e.g., expat regime)</li>
               <li>View the detailed breakdown of taxes and contributions</li>
-              <li>Add more countries to compare side-by-side (up to 4)</li>
+              <li>Add more destinations to compare side-by-side (up to 4)</li>
               <li>Share your comparison with the shareable URL</li>
             </ol>
           </CardContent>
@@ -194,7 +194,7 @@ export default async function HelpPage() {
                 </AccordionTrigger>
                 <AccordionContent>
                   <p className="text-sm text-muted-foreground mb-3">
-                    Yes! Click &quot;Add Country&quot; to add up to 4 countries for
+                    Yes! Click &quot;Add Destination&quot; to add up to 4 destinations for
                     side-by-side comparison. Currency conversion is handled
                     automatically using recent exchange rates.
                   </p>

--- a/src/components/calculator/country-column.tsx
+++ b/src/components/calculator/country-column.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useCallback, useRef } from "react"
 import { toast } from "sonner"
-import { X, Copy } from "lucide-react"
+import { X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -42,8 +42,6 @@ interface CountryColumnProps extends CountryColumnState {
   onUpdate: (updates: Partial<CountryColumnState>) => void
   onRemove: () => void
   showRemove?: boolean
-  showCopyToAll?: boolean
-  onCopyGrossToAll?: () => void
   isBest?: boolean
   comparisonDelta?: number
 }
@@ -63,8 +61,6 @@ export function CountryColumn({
   onUpdate,
   onRemove,
   showRemove = true,
-  showCopyToAll = false,
-  onCopyGrossToAll,
   isBest = false,
   comparisonDelta,
 }: CountryColumnProps) {
@@ -316,27 +312,6 @@ export function CountryColumn({
                   />
                 )}
               </div>
-              {showCopyToAll && gross_annual && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 px-2 md:h-5 md:px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                        onClick={onCopyGrossToAll}
-                      >
-                        <Copy className="h-3 w-3 mr-1" />
-                        <span className="hidden sm:inline">Copy all</span>
-                        <span className="sm:hidden">Copy</span>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Copy salary to all countries (converts currency)</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
             </div>
             <div className="relative">
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">

--- a/src/components/calculator/mobile-country-selector.tsx
+++ b/src/components/calculator/mobile-country-selector.tsx
@@ -39,7 +39,7 @@ export function MobileCountrySelector({
                 {country ? getCountryFlag(country) : "🌍"}
               </span>
               <span className="text-xs">
-                {country ? getCountryName(country) : `Country ${index + 1}`}
+                {country ? getCountryName(country) : `Destination ${index + 1}`}
               </span>
             </TabsTrigger>
           ))}
@@ -52,7 +52,7 @@ export function MobileCountrySelector({
           variant="outline"
           size="icon"
           className="shrink-0"
-          aria-label="Add country"
+          aria-label="Add destination"
         >
           <Plus className="h-4 w-4" />
         </Button>

--- a/tests/e2e/salary-mode-toggle.spec.ts
+++ b/tests/e2e/salary-mode-toggle.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Salary mode toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/calculator')
+  })
+
+  test('renders both mode options', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: 'Same salary' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Local salaries' })).toBeVisible()
+  })
+
+  test('defaults to Same salary mode', async ({ page }) => {
+    const sameSalary = page.getByRole('tab', { name: 'Same salary' })
+    await expect(sameSalary).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('switches to Local salaries mode on click', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Local salaries' }).click()
+    await expect(page.getByRole('tab', { name: 'Local salaries' })).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByRole('tab', { name: 'Same salary' })).toHaveAttribute('aria-selected', 'false')
+  })
+
+  test('switching back to Same salary works', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Local salaries' }).click()
+    await page.getByRole('tab', { name: 'Same salary' }).click()
+    await expect(page.getByRole('tab', { name: 'Same salary' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('shows tooltip on hover', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Same salary' }).hover()
+    await expect(page.getByRole('tooltip').first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- **#43** Renamed "Add Country" to "Add Destination" throughout the UI
- **#40 + #42** Replaced the broken copy-all button with a salary mode toggle:
  - **Same salary** (default): gross syncs across all columns with live currency conversion; new columns auto-fill and re-convert when a country is picked
  - **Local salaries**: each column is fully independent
  - Tooltips explain each mode
- Playwright configured on port 3938 to avoid dev server conflicts
- E2e tests added for the toggle (5 passing)
- Developer skill updated with UI component and e2e conventions

## Note
Backend currency conversion bug (part of #40) is tracked separately and assigned to @pascalwhoop.

## Test plan
- [ ] `BASE_URL=http://localhost:3000 npm run test:e2e` — 5 tests pass
- [ ] Same salary: typing gross in one column converts others correctly
- [ ] Same salary: adding a third column auto-fills on country selection
- [ ] Local salaries: columns stay independent
- [ ] Tooltips appear on hover over each mode
- [ ] "Add Destination" label shown everywhere

Closes #42
Closes #43