### PR TITLE
feat: tax deduction framework (#27)

### DIFF
--- a/configs/nl/2025/base.yaml
+++ b/configs/nl/2025/base.yaml
@@ -75,6 +75,48 @@ inputs:
         label: "With Fiscal Partner"
         description: "Married or registered partnership (used for credit distribution)"
 
+  # Optional deduction inputs
+  mortgage_interest_paid:
+    type: number
+    required: false
+    min: 0
+    default: 0
+    label: "Mortgage Interest Paid (Optional)"
+    description: "Annual interest paid on your mortgage for primary residence (hypotheekrente)"
+
+  mortgage_start_year:
+    type: number
+    required: false
+    min: 1990
+    max: 2025
+    default: 2024
+    label: "Mortgage Start Year (Optional)"
+    description: "Year when mortgage was first taken out (for 30-year eligibility check)"
+
+  pension_contributions:
+    type: number
+    required: false
+    min: 0
+    default: 0
+    label: "Pension/Annuity Contributions (Optional)"
+    description: "Additional pension or annuity contributions (lijfrentepremies)"
+
+  jaarruimte_available:
+    type: number
+    required: false
+    min: 0
+    default: 0
+    label: "Available Jaarruimte (Optional)"
+    description: "Your available annual allowance for pension deductions from previous year"
+
+  healthcare_expenses:
+    type: number
+    required: false
+    min: 0
+    default: 0
+    label: "Healthcare Expenses (Optional)"
+    description: "Out-of-pocket medical and healthcare costs (specifieke zorgkosten)"
+
 parameters:
   # Income tax brackets for Box 1 (under AOW age) - 2025 rates
   # These include income tax + social security premiums
@@ -115,13 +157,135 @@ parameters:
       rate: 0
       base: 0
 
-calculations:
-  # Taxable income (for standard case, same as gross)
-  - id: taxable_income
-    type: identity
-    value: "@gross_annual"
+  # Deduction parameters
+  mortgage_interest_max_rate: 0.3748  # Maximum deduction rate for 2025
+  mortgage_max_years: 30
+  current_year: 2025
 
-  # Income tax (bracket tax on full income)
+  # Healthcare threshold parameters (simplified approximation)
+  healthcare_threshold_fixed: 132
+  healthcare_threshold_rate: 0.0165
+  healthcare_threshold_income_start: 8625
+
+calculations:
+  # ============================================================================
+  # DEDUCTION CALCULATIONS
+  # ============================================================================
+  # Calculate all deductions first, then adjust taxable income
+
+  # Mortgage interest deduction
+  - id: has_mortgage_data
+    type: conditional
+    condition:
+      type: gt
+      left: "@mortgage_interest_paid"
+      right: 0
+    then:
+      type: conditional
+      condition:
+        type: gt
+        left: "@mortgage_start_year"
+        right: 0
+      then: 1
+      else: 0
+    else: 0
+
+  - id: mortgage_years_elapsed
+    type: conditional
+    condition:
+      type: gt
+      left: "$has_mortgage_data"
+      right: 0
+    then:
+      type: sub
+      values:
+        - "$current_year"
+        - "@mortgage_start_year"
+    else: 999
+
+  - id: mortgage_within_30_years
+    type: conditional
+    condition:
+      type: lte
+      left: "$mortgage_years_elapsed"
+      right: "$mortgage_max_years"
+    then: 1
+    else: 0
+
+  - id: mortgage_interest_deduction
+    type: deduction
+    amount:
+      type: mul
+      values:
+        - "@mortgage_interest_paid"
+        - "$mortgage_within_30_years"
+    rate_limit: "$mortgage_interest_max_rate"
+    category: deduction
+    label: "Mortgage Interest"
+    description: "Hypotheekrente (max 30 years, 37.48% rate)"
+
+  # Pension contribution deduction
+  - id: pension_contribution_deduction
+    type: deduction
+    amount: "@pension_contributions"
+    cap: "@jaarruimte_available"
+    rate_limit: "$mortgage_interest_max_rate"
+    category: deduction
+    label: "Pension Contributions"
+    description: "Lijfrentepremies (capped by jaarruimte)"
+
+  # Healthcare cost deduction
+  - id: healthcare_threshold_variable
+    type: mul
+    values:
+      - type: max
+        values:
+          - 0
+          - type: sub
+            values:
+              - "@gross_annual"
+              - "$healthcare_threshold_income_start"
+      - "$healthcare_threshold_rate"
+
+  - id: healthcare_threshold_total
+    type: sum
+    values:
+      - "$healthcare_threshold_fixed"
+      - "$healthcare_threshold_variable"
+
+  - id: healthcare_deduction
+    type: deduction
+    amount: "@healthcare_expenses"
+    threshold:
+      amount: "$healthcare_threshold_total"
+      mode: "above"
+    category: deduction
+    label: "Healthcare Costs"
+    description: "Specifieke zorgkosten (only above threshold)"
+
+  # Total deductions
+  - id: total_deductions
+    type: sum
+    values:
+      - "$mortgage_interest_deduction"
+      - "$pension_contribution_deduction"
+      - "$healthcare_deduction"
+
+  # ============================================================================
+  # TAXABLE INCOME
+  # ============================================================================
+  # Gross income minus deductions
+
+  - id: taxable_income
+    type: sub
+    values:
+      - "@gross_annual"
+      - "$total_deductions"
+
+  # ============================================================================
+  # TAX CALCULATIONS
+  # ============================================================================
+  # Income tax (bracket tax on taxable income after deductions)
   - id: income_tax_and_social_security
     type: bracket_tax
     base: "$taxable_income"
@@ -291,6 +455,10 @@ outputs:
   breakdown:
     taxes:
       - "$income_tax_and_social_security"
+    deductions:
+      - "$mortgage_interest_deduction"
+      - "$pension_contribution_deduction"
+      - "$healthcare_deduction"
     credits:
       - "$general_tax_credit"
       - "$labour_tax_credit"

--- a/configs/nl/2025/tests/deduction-baseline.json
+++ b/configs/nl/2025/tests/deduction-baseline.json
@@ -1,0 +1,26 @@
+{
+  "name": "Baseline - No deductions",
+  "description": "\u20ac50,000 gross with no deductions to verify backward compatibility",
+  "inputs": {
+    "gross_annual": 50000,
+    "filing_status": "single",
+    "mortgage_interest_paid": 0,
+    "mortgage_start_year": 0,
+    "pension_contributions": 0,
+    "jaarruimte_available": 0,
+    "healthcare_expenses": 0
+  },
+  "expected": {
+    "net": 38746,
+    "effective_rate": 0.22509
+  },
+  "tolerance": 10,
+  "tolerance_percent": 0.005,
+  "sources": [
+    {
+      "url": "https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/prive/inkomstenbelasting/heffingskortingen_boxen_tarieven/boxen_en_tarieven/box_1/box_1",
+      "description": "Official 2025 tax rates",
+      "retrieved_at": "2026-01-31"
+    }
+  ]
+}

--- a/configs/nl/2025/tests/deduction-healthcare.json
+++ b/configs/nl/2025/tests/deduction-healthcare.json
@@ -1,0 +1,26 @@
+{
+  "name": "Healthcare cost deduction",
+  "description": "\u20ac60,000 gross with \u20ac2,000 healthcare expenses (threshold ~\u20ac980, deduction ~\u20ac1,020)",
+  "inputs": {
+    "gross_annual": 60000,
+    "filing_status": "single",
+    "mortgage_interest_paid": 0,
+    "mortgage_start_year": 0,
+    "pension_contributions": 0,
+    "jaarruimte_available": 0,
+    "healthcare_expenses": 2000
+  },
+  "expected": {
+    "net": 44226,
+    "effective_rate": 0.26289
+  },
+  "tolerance": 15,
+  "tolerance_percent": 0.005,
+  "sources": [
+    {
+      "url": "https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/prive/relatie_familie_en_gezondheid/gezondheid/aftrek_zorgkosten/",
+      "description": "Healthcare cost deduction rules",
+      "retrieved_at": "2026-01-31"
+    }
+  ]
+}

--- a/configs/nl/2025/tests/deduction-mortgage.json
+++ b/configs/nl/2025/tests/deduction-mortgage.json
@@ -1,0 +1,26 @@
+{
+  "name": "Mortgage interest deduction",
+  "description": "\u20ac60,000 gross with \u20ac10,000 mortgage interest (started 2020, within 30-year limit)",
+  "inputs": {
+    "gross_annual": 60000,
+    "filing_status": "single",
+    "mortgage_interest_paid": 10000,
+    "mortgage_start_year": 2020,
+    "pension_contributions": 0,
+    "jaarruimte_available": 0,
+    "healthcare_expenses": 0
+  },
+  "expected": {
+    "net": 48095,
+    "effective_rate": 0.19842
+  },
+  "tolerance": 20,
+  "tolerance_percent": 0.005,
+  "sources": [
+    {
+      "url": "https://www.iamexpat.nl/housing/buy-house-netherlands/mortgage-tax-deductions",
+      "description": "Mortgage tax deductions in the Netherlands",
+      "retrieved_at": "2026-01-31"
+    }
+  ]
+}

--- a/configs/nl/2025/tests/deduction-pension-capped.json
+++ b/configs/nl/2025/tests/deduction-pension-capped.json
@@ -1,0 +1,26 @@
+{
+  "name": "Pension contribution capped by jaarruimte",
+  "description": "\u20ac75,000 gross with \u20ac10,000 pension contribution but only \u20ac6,000 jaarruimte available",
+  "inputs": {
+    "gross_annual": 75000,
+    "filing_status": "single",
+    "mortgage_interest_paid": 0,
+    "mortgage_start_year": 0,
+    "pension_contributions": 10000,
+    "jaarruimte_available": 6000,
+    "healthcare_expenses": 0
+  },
+  "expected": {
+    "net": 53793,
+    "effective_rate": 0.28276
+  },
+  "tolerance": 20,
+  "tolerance_percent": 0.005,
+  "sources": [
+    {
+      "url": "https://www.belastingdienst.nl/wps/wcm/connect/nl/aftrek-en-kortingen/content/hoe-bereken-ik-mijn-jaarruimte",
+      "description": "Jaarruimte cap for pension deductions",
+      "retrieved_at": "2026-01-31"
+    }
+  ]
+}

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -19,9 +19,25 @@ export class CalculationEngine {
   }
 
   calculate(inputs: Record<string, string | number | boolean | Record<string, unknown> | undefined>): CalculationResult {
+    // Apply input defaults for optional inputs not provided
+    const inputsWithDefaults: Record<string, string | number | boolean | Record<string, unknown> | undefined> = {}
+    for (const [key, def] of Object.entries(this.config.inputs)) {
+      if (inputs[key] !== undefined) {
+        inputsWithDefaults[key] = inputs[key]
+      } else if ('default' in def && def.default !== undefined) {
+        inputsWithDefaults[key] = def.default as string | number | boolean
+      }
+    }
+    // Also include any extra inputs not in config definitions
+    for (const [key, value] of Object.entries(inputs)) {
+      if (inputsWithDefaults[key] === undefined) {
+        inputsWithDefaults[key] = value
+      }
+    }
+
     // Initialize context
     const context: CalculationContext = {
-      inputs: { ...inputs },
+      inputs: inputsWithDefaults,
       parameters: this.config.parameters,
       nodes: {},
       config: {

--- a/packages/engine/src/evaluators.ts
+++ b/packages/engine/src/evaluators.ts
@@ -341,12 +341,30 @@ function evaluateDeduction(
 ): number {
   let amount = resolveValue(node.amount, context, functions)
 
+  // Apply threshold if specified
+  if (node.threshold) {
+    const thresholdAmount = resolveValue(node.threshold.amount, context, functions)
+    if (node.threshold.mode === 'above') {
+      // Only amount above threshold is deductible
+      amount = Math.max(0, amount - thresholdAmount)
+    } else if (node.threshold.mode === 'below') {
+      // Only amount below threshold is deductible
+      amount = Math.min(amount, thresholdAmount)
+    }
+  }
+
+  // Apply cap if specified
   if (node.cap !== undefined) {
     const cap = resolveValue(node.cap, context, functions)
     amount = Math.min(amount, cap)
   }
 
-  return amount
+  // Apply phaseout if specified
+  if (node.phaseout) {
+    amount = applyPhaseout(amount, node.phaseout, context, functions)
+  }
+
+  return Math.max(0, amount) // Never negative
 }
 
 // Control flow evaluators

--- a/packages/schema/src/config-types.ts
+++ b/packages/schema/src/config-types.ts
@@ -196,10 +196,18 @@ export interface CreditNode extends BaseNode {
   label?: string
 }
 
+export interface ThresholdConfig {
+  amount: string | number // Threshold value (can be reference or inline calc)
+  mode: 'above' | 'below' // Deduct only amount above or below threshold
+}
+
 export interface DeductionNode extends BaseNode {
   type: 'deduction'
-  amount: string | number
+  amount: string | number | InlineNode
   cap?: string | number
+  threshold?: ThresholdConfig // Only amounts above/below threshold are deductible
+  rate_limit?: number // Maximum tax rate at which deduction provides benefit (metadata)
+  phaseout?: PhaseoutConfig // Reduce deduction based on income
   category?: NodeCategory
   label?: string
 }

--- a/src/components/calculator/country-column.tsx
+++ b/src/components/calculator/country-column.tsx
@@ -24,7 +24,8 @@ import {
 import { ResultBreakdown } from "./result-breakdown"
 import { SalaryRangeChart } from "./salary-range-chart"
 import { NoticeIcon } from "./notices"
-import { getCountryName, getCurrencySymbol, type CalcRequest } from "@/lib/api"
+import { getCountryName, getCurrencySymbol, type CalcRequest, type InputDefinition } from "@/lib/api"
+import { DeductionManager } from "./deduction-manager"
 import { CountryColumnState } from "@/lib/types"
 import { getCountryFlag } from "@/lib/country-metadata"
 import { Crown } from "lucide-react"
@@ -160,13 +161,19 @@ export function CountryColumn({
 
     // Add form values
     for (const [key, value] of Object.entries(formValues)) {
-      if (key !== "gross_annual" && value) {
-        const inputDef = inputsData?.inputs[key]
-        if (inputDef?.type === "boolean") {
-          request[key] = value === "true"
-        } else {
-          request[key] = value
+      if (key === "gross_annual") continue
+
+      const inputDef = inputsData?.inputs[key] as InputDefinition | undefined
+
+      if (inputDef?.type === "boolean") {
+        request[key] = value === "true"
+      } else if (inputDef?.type === "number") {
+        const numValue = parseFloat(value || "0")
+        if (!isNaN(numValue)) {
+          request[key] = numValue
         }
+      } else if (value) {
+        request[key] = value
       }
     }
 
@@ -393,6 +400,14 @@ export function CountryColumn({
               ))}
             </div>
           )}
+
+          {/* Deductions Manager */}
+          <DeductionManager
+            inputDefs={inputDefs}
+            formValues={formValues}
+            onUpdateFormValue={updateFormValue}
+            columnIndex={index}
+          />
 
           {/* Variant Selection */}
           {variants.length > 0 && (

--- a/src/components/calculator/deduction-manager.tsx
+++ b/src/components/calculator/deduction-manager.tsx
@@ -1,0 +1,292 @@
+"use client"
+
+import { Plus, X, Edit2 } from "lucide-react"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { InputDefinition } from "@/lib/api"
+
+interface DeductionManagerProps {
+  inputDefs: Record<string, InputDefinition>
+  formValues: Record<string, string>
+  onUpdateFormValue: (key: string, value: string) => void
+  columnIndex: number
+}
+
+// Define compound deductions (deductions that require multiple fields)
+const COMPOUND_DEDUCTIONS: Record<string, string[]> = {
+  mortgage_interest_paid: ["mortgage_interest_paid", "mortgage_start_year"],
+  pension_contributions: ["pension_contributions", "jaarruimte_available"],
+}
+
+interface DeductionInput {
+  key: string
+  def: InputDefinition
+}
+
+export function DeductionManager({
+  inputDefs,
+  formValues,
+  onUpdateFormValue,
+  columnIndex,
+}: DeductionManagerProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedDeduction, setSelectedDeduction] = useState<string | null>(null)
+
+  // Get all number inputs except gross_annual (these are deductions)
+  const deductionInputs: DeductionInput[] = Object.entries(inputDefs)
+    .filter(([key, def]) => def.type === "number" && key !== "gross_annual")
+    .map(([key, def]) => ({ key, def }))
+
+  // Get primary deduction keys (the main field for each deduction group)
+  const primaryDeductionKeys = new Set(Object.keys(COMPOUND_DEDUCTIONS))
+
+  // Filter to only show primary deduction fields (not secondary fields like mortgage_start_year)
+  const primaryDeductions = deductionInputs.filter(({ key }) => {
+    // If it's a compound deduction primary key, show it
+    if (primaryDeductionKeys.has(key)) return true
+
+    // If it's not part of any compound deduction, show it
+    const isSecondaryField = Object.values(COMPOUND_DEDUCTIONS).some(fields =>
+      fields.includes(key) && fields[0] !== key
+    )
+    return !isSecondaryField
+  })
+
+  // Check if a deduction is active (all required fields are non-zero)
+  const isDeductionActive = (primaryKey: string): boolean => {
+    const relatedFields = COMPOUND_DEDUCTIONS[primaryKey] || [primaryKey]
+    return relatedFields.every(field => {
+      const value = parseFloat(formValues[field] || "0")
+      return value > 0
+    })
+  }
+
+  // Get active deductions
+  const activeDeductions = primaryDeductions.filter(({ key }) => isDeductionActive(key))
+
+  // Get available deductions
+  const availableDeductions = primaryDeductions.filter(({ key }) => !isDeductionActive(key))
+
+  const handleOpenAddDialog = () => {
+    setSelectedDeduction(null)
+    setDialogOpen(true)
+  }
+
+  const handleOpenEditDialog = (key: string) => {
+    setSelectedDeduction(key)
+    setDialogOpen(true)
+  }
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false)
+    setSelectedDeduction(null)
+  }
+
+  const handleRemoveDeduction = (key: string) => {
+    // Remove all related fields
+    const relatedFields = COMPOUND_DEDUCTIONS[key] || [key]
+    relatedFields.forEach(field => {
+      onUpdateFormValue(field, "0")
+    })
+  }
+
+  const handleSelectDeduction = (key: string) => {
+    setSelectedDeduction(key)
+  }
+
+  // Inputs update parent formValues directly
+  const handleInputChange = (key: string, value: string) => {
+    onUpdateFormValue(key, value)
+  }
+
+  if (deductionInputs.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Active Deductions List */}
+      {activeDeductions.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-xs text-muted-foreground">Active Deductions</Label>
+          <div className="space-y-1.5">
+            {activeDeductions.map(({ key, def }) => {
+              const value = parseFloat(formValues[key] || "0")
+              return (
+                <div
+                  key={key}
+                  className="flex items-center justify-between p-2 rounded-md border bg-muted/30 text-sm"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate">{def.label || key}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {value.toLocaleString()}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 ml-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={() => handleOpenEditDialog(key)}
+                    >
+                      <Edit2 className="h-3 w-3" />
+                      <span className="sr-only">Edit</span>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      onClick={() => handleRemoveDeduction(key)}
+                    >
+                      <X className="h-3 w-3" />
+                      <span className="sr-only">Remove</span>
+                    </Button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Add Deduction Button */}
+      {availableDeductions.length > 0 && (
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={handleOpenAddDialog}
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Deduction
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-[500px]">
+            <DialogHeader>
+              <DialogTitle>
+                {selectedDeduction ? "Edit Deduction" : "Add Deduction"}
+              </DialogTitle>
+              <DialogDescription>
+                {selectedDeduction
+                  ? "Update the deduction amount"
+                  : "Select a deduction type and enter the amount"}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-4">
+              {/* Deduction Type Selection (only when adding new) */}
+              {!selectedDeduction && (
+                <div className="space-y-2">
+                  <Label htmlFor={`deduction-type-${columnIndex}`}>
+                    Deduction Type
+                  </Label>
+                  <Select onValueChange={handleSelectDeduction}>
+                    <SelectTrigger id={`deduction-type-${columnIndex}`}>
+                      <SelectValue placeholder="Select a deduction type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableDeductions.map(({ key, def }) => (
+                        <SelectItem key={key} value={key}>
+                          <div className="flex flex-col items-start">
+                            <span className="font-medium">{def.label || key}</span>
+                            {def.description && (
+                              <span className="text-xs text-muted-foreground">
+                                {def.description}
+                              </span>
+                            )}
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              {/* Amount Input (shown when deduction is selected) */}
+              {selectedDeduction && (
+                <>
+                  {/* Show deduction info */}
+                  <div className="rounded-md bg-muted/50 p-3 space-y-1">
+                    <div className="font-medium">
+                      {inputDefs[selectedDeduction]?.label || selectedDeduction}
+                    </div>
+                    {inputDefs[selectedDeduction]?.description && (
+                      <div className="text-xs text-muted-foreground">
+                        {inputDefs[selectedDeduction].description}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Render all related input fields */}
+                  {(COMPOUND_DEDUCTIONS[selectedDeduction] || [selectedDeduction]).map((fieldKey) => {
+                    const fieldDef = inputDefs[fieldKey]
+                    if (!fieldDef) return null
+
+                    return (
+                      <div key={fieldKey} className="space-y-2">
+                        <Label htmlFor={`${fieldKey}-${columnIndex}`}>
+                          {fieldDef.label || fieldKey}
+                        </Label>
+                        <Input
+                          id={`${fieldKey}-${columnIndex}`}
+                          type="number"
+                          min={fieldDef.min || 0}
+                          max={fieldDef.max}
+                          placeholder="0"
+                          value={formValues[fieldKey] || "0"}
+                          onChange={(e) => handleInputChange(fieldKey, e.target.value)}
+                        />
+                        {fieldDef.description && (
+                          <p className="text-xs text-muted-foreground">
+                            {fieldDef.description}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })}
+                </>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={handleCloseDialog}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleCloseDialog}
+                disabled={!selectedDeduction}
+              >
+                {selectedDeduction && isDeductionActive(selectedDeduction)
+                  ? "Update"
+                  : "Add"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Extends `DeductionNode` schema with `threshold`, `rate_limit`, and `phaseout` support
- Updates deduction evaluator to apply threshold (above/below), cap, and phaseout rules
- Fixes engine to apply input defaults for optional inputs not provided by the caller
- Adds NL 2025 optional deductions: mortgage interest, pension contributions, healthcare costs
- Adds `DeductionManager` UI component for managing optional deductions per column
- Fixes `CountryColumn` number input parsing (was sending strings instead of numbers)

## Test plan

- [ ] `npm run test:configs` — all 213 config tests pass including 4 new NL deduction vectors
- [ ] `npm run test:run` — all 290 tests pass
- [ ] `npm run lint && npx tsc --noEmit` — clean
- [ ] Open NL column → click "Add deduction" → enter mortgage interest → verify net changes
- [ ] Verify baseline (no deductions) matches existing test vectors

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)