### PR TITLE
fix(ui): stack filing status and federal state in single column

### DIFF
--- a/src/components/calculator/country-column.tsx
+++ b/src/components/calculator/country-column.tsx
@@ -335,11 +335,11 @@ export function CountryColumn({
             </div>
           </div>
 
-          {/* Dynamic Enum Inputs */}
+          {/* Dynamic Enum Inputs - single column so long labels/options fit */}
           {enumInputs.length > 0 && (
-            <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-2">
               {enumInputs.map(([key, def]) => (
-                <div key={key} className="space-y-1">
+                <div key={key} className="space-y-1 min-w-0">
                   <Label htmlFor={`${key}-${index}`} className="text-xs text-muted-foreground">
                     {def.label || key}
                   </Label>
@@ -347,7 +347,7 @@ export function CountryColumn({
                     value={formValues[key] || (def.default ? String(def.default) : "__none__")}
                     onValueChange={v => updateFormValue(key, v === "__none__" ? "" : v)}
                   >
-                    <SelectTrigger id={`${key}-${index}`} className="h-10 md:h-9">
+                    <SelectTrigger id={`${key}-${index}`} className="h-10 md:h-9 w-full">
                       <SelectValue placeholder="Select" />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
Filing Status and Federal State (and other dynamic enum inputs) were in a 2-column grid inside the country card, so they got squished and overflowed in narrow columns.

**Changes:**
- Render dynamic enum inputs in a single column (`space-y-2`) so each field gets full width.
- Add `w-full` to the SelectTrigger and `min-w-0` on the wrapper so they fit the card and don’t overflow.

Country and Year stay in a 2-column row (short values).

Made with [Cursor](https://cursor.com)